### PR TITLE
feat: Increase App Hosting memory to 4096MiB

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -5,6 +5,6 @@ runConfig:
   minInstances: 0
   maxInstances: 10 # Increased from 1 to address scalability bottleneck (Phase 1.A.1)
   concurrency: 80 # Default, can be tuned
-  memoryMiB: 512 # Default, can be tuned
+  memoryMiB: 4096 # Default, can be tuned
   timeoutSeconds: 60 # Default, can be tuned
-# cpu: 1 # Default, can be set if specific CPU needs are identified
+  cpu: 1 # Default, can be set if specific CPU needs are identified


### PR DESCRIPTION
I've increased the memoryMiB for the Firebase App Hosting backend from 512MiB to 4096MiB. I also explicitly set CPU to 1 to align with the increased memory, as per documentation recommendations for memory up to 4GiB.

This change aims to improve your application's performance and stability by providing more memory resources. Further scaling options are available if needed, which would involve increasing CPU allocation as well.