### PR TITLE
Fix README and add roadmap folder map

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ For more details on phases and planned work, consult the [Strategic Roadmap](doc
 - **OpenTelemetry build warnings**: During `npm run build`, Next.js may warn about missing `@opentelemetry/exporter-jaeger` or the `require.extensions` API. These come from Genkit's optional tracing setup. The warnings are harmless but can be silenced by installing the Jaeger exporter:
   ```bash
   npm install --save-dev @opentelemetry/exporter-jaeger
+
+```
+- **Emulator port already in use**: If the Firebase emulators fail to start, check for other processes using the ports and kill them or adjust `firebase.json`.

--- a/docs/folder_phase_map.md
+++ b/docs/folder_phase_map.md
@@ -1,0 +1,16 @@
+# Repository Folder ⇔ Roadmap Phase Map
+
+| Folder | Description | Related Phase |
+| --- | --- | --- |
+| `/src/` | Application code and Genkit flows | Phase 1: Core Infrastructure |
+| `/iam_infra/` | Terraform modules and secrets setup | Phase 2: Security & Secrets |
+| `/isa_devops_ci_cd_v4/` | CI/CD and observability configs | Phase 3: Observability & Automation |
+| `/docs/` | Architecture and self‑healing docs | Phases 4 & 9 |
+| `/dataconnect/` | Data ingestion configuration | Phase 5: KG Core |
+| `/dataconnect-generated/` | Generated ingestion output | Phase 6: GraphRAG |
+| `/ISA_AutoResearch_Kit/` | Prompts for automated research | Phase 8: AI Evaluation |
+| `/ISA_Future_Phases_*` | Planning for agentic & autonomous phases | Phases 10–18 |
+| `/scripts/` | General utilities and setup scripts | Multi-phase |
+
+This table links repository structure with the chronological roadmap so contributors can easily locate phase-specific materials. Later-phase folders serve primarily as references for future work.
+


### PR DESCRIPTION
## Summary
- fix truncated README Troubleshooting section and add emulator note
- create folder-phase map for locating roadmap material

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: cannot find various modules)*

------
https://chatgpt.com/codex/tasks/task_e_685136de02a483329eb739fcbb37a234