### PR TITLE
Add pre-commit test hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See `docs/blueprint.md` for a complete roadmap and architectural log. IAM automa
    ```bash
    ./scripts/setup.sh
    ```
-   This installs dependencies, copies `.env.example` to `.env` if needed, runs lint and type checks, and builds the project.
+   This installs dependencies, copies `.env.example` to `.env` if needed, installs git hooks, runs lint and type checks, and builds the project.
 2. **Configure environment variables**
   Copy `.env.example` to `.env` and fill in each placeholder with your credentials. The file lists
   all variables used for local development, including API keys and emulator settings.
@@ -39,6 +39,7 @@ For detailed instructions on configuring Firebase emulators, VS Code, and Roocod
 - `npm run build` – build the Next.js application
 - `npm run lint` – run ESLint
 - `npm run typecheck` – run TypeScript type checks
+- Git hooks installed by `setup.sh` run `npm test` before each commit.
 
 ## Core Features
 - Document Q&A and standards analysis

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Git pre-commit hook to run tests before allowing a commit
+npm test

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,13 @@ else
   echo "[setup] npm dependencies already installed"
 fi
 
+# Install git hooks
+if [ -d .git ]; then
+  echo "[setup] Installing git hooks"
+  cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+fi
+
 # Run lint and type checks
 npm run lint || echo "[setup] Lint failed or not configured"
 npm run typecheck || echo "[setup] Typecheck failed"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -62,9 +62,8 @@ fi
 
 # Install git hooks
 if [ -d .git ]; then
-  echo "[setup] Installing git hooks"
-  cp scripts/git-hooks/pre-commit .git/hooks/pre-commit
-  chmod +x .git/hooks/pre-commit
+  echo "[setup] Configuring git hooks path"
+  git config core.hooksPath scripts/git-hooks
 fi
 
 # Export environment versions


### PR DESCRIPTION
## Summary
- add a `pre-commit` hook that runs `npm test`
- install git hooks from `setup.sh`
- document hook behaviour in `README`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516aff25648332a9cc1ab962424a7b